### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -115,57 +115,53 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <% @items.each do |item|%>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-      <%# 実装前：商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+              <%# 実装前：商品が売れていればsold outを表示しましょう %>
+              <%# <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div> %>
+              <%# //実装前：商品が売れていればsold outを表示しましょう %>
 
-          <%# 実装前：商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //実装前：商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //実装前 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 実装前 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 実装前 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= "税込み" %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
+          <% end %>
+        </li>
+      <% end %>
+        <% if @items.empty? %>
+          <li class='list'>
+            <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //実装前 商品がある場合は表示されないようにしましょう %>
-      <%# //実装前 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
# What
 商品一覧表示機能を実装

# Why
 出品した商品を一覧画面に表示させるため

# 機能キャプチャ
　・最新の出品順に商品が一覧表示されていること
　　Sequel Pro (https://gyazo.com/447d05f0f679e21b70b0d6f1de7c22de)
　　一覧画面(https://gyazo.com/002126543015dd86b23fd00cd485cfa3)
　・出品されている商品がないとき、サンプル画像が表示されること
　　Sequel Pro (https://gyazo.com/33df529a1c9f18195cc445f15422c4a8)
　　一覧画面(https://gyazo.com/bf7edcfdd966372ab057cf4ba08a3f71)
　・ログインユーザが一覧表示画面が見えること
　　(https://gyazo.com/ef96424828ade99a2478ceb2c51f0620)
　・ログアウトしたユーザが一覧表示画面が見えること
　　(https://gyazo.com/e7814cd052d68104db350498180d2112)
# 注釈
 商品購入機能が未実装なので、Sold Outの表示は実装していません。