### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @category = Category.data.find{|o| o[:id] == @item.category_id}
+    @condition = Condition.data.find{|o| o[:id] == @item.condition_id}
+    @delivery_day = DeliveryDay.data.find{|o| o[:id] == @item.delivery_day_id}
+    @ship_from_region = ShipFromRegion.data.find{|o| o[:id] == @item.ship_from_region_id}
+    @shipping_fee_person = ShippingFeePerson.data.find{|o| o[:id] == @item.shipping_fee_person_id}
+  end
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,13 +20,8 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @category = Category.data.find{|o| o[:id] == @item.category_id}
-    @condition = Condition.data.find{|o| o[:id] == @item.condition_id}
-    @delivery_day = DeliveryDay.data.find{|o| o[:id] == @item.delivery_day_id}
-    @ship_from_region = ShipFromRegion.data.find{|o| o[:id] == @item.ship_from_region_id}
-    @shipping_fee_person = ShippingFeePerson.data.find{|o| o[:id] == @item.shipping_fee_person_id}
   end
-  private
+    private
 
   def item_params
     params.require(:item).permit(:image, :name, :description, :category_id, :condition_id, :shipping_fee_person_id,

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,11 @@ class Item < ApplicationRecord
   belongs_to :user
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :category, :condition, :delivery_day, :ship_from_region, :shipping_fee_person
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :delivery_day 
+  belongs_to :shipping_fee_person
+  belongs_to :ship_from_region
 
   with_options presence: true do
     validates :image, :name, :description

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -117,7 +117,7 @@
     <ul class='item-lists'>
       <% @items.each do |item|%>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,7 +18,7 @@
         <%= "¥#{@item.price}"%>
       </span>
       <span class="item-postage">
-        <%= @shipping_fee_person[:pay] %>
+        <%= @item.shipping_fee_person.pay %> 
       </span>
     </div>
 
@@ -45,23 +45,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @category[:name] %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @condition[:status] %></td>
+          <td class="detail-value"><%= @item.condition.status %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @shipping_fee_person[:pay] %></td>
+          <td class="detail-value"><%= @item.shipping_fee_person.pay %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @ship_from_region[:region] %></td>
+          <td class="detail-value"><%= @item.ship_from_region.region %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @delivery_day[:days] %></td>
+          <td class="detail-value"><%= @item.delivery_day.days %></td>
         </tr>
       </tbody>
     </table>
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class="another-item"><%= @category[:name] %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,106 @@
+<%= render "shared/header" %>
+
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= "¥#{@item.price}"%>
+      </span>
+      <span class="item-postage">
+        <%= @shipping_fee_person[:pay] %>
+      </span>
+    </div>
+
+    <% if user_signed_in?%> 
+      <%if current_user.id == @item.user.id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @category[:name] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @condition[:status] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @shipping_fee_person[:pay] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @ship_from_region[:region] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @delivery_day[:days] %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class="another-item"><%= @category[:name] %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index,:new,:create]
+  resources :items, only: [:index,:new,:create,:show]
 end


### PR DESCRIPTION
# What
  商品詳細表示機能を実装

# Why
  出品した商品の詳細情報と購入・編集・削除ができるようにするため

# 画面キャプチャ
　・ログインユーザ＝商品出品者のとき編集・削除ボタンが表示されること
　　(https://gyazo.com/7c4c33904f44cb4f81873b42e73799a2)
　・出品情報と詳細表示画面の登録情報が一致すること ※↑詳細表示画面と↓出品画面の情報を目視で比較
　　(https://gyazo.com/52dd391c306cfa3a4e3dd6cebb3b486d)
　・ログインユーザ≠商品出品者のとき購入画面に進むボタンが表示されること
　　(https://gyazo.com/f56fdc62ab2b96885e68a3926a3318f5)
　・ログアウトユーザはページの閲覧のみできること
　　(https://gyazo.com/88b53fe2f5bd0768915a0eb0bb963df5)
# 注釈
　購入機能は未実装のため、Sold Outの表示はしていません。